### PR TITLE
Fix makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -20,10 +20,10 @@ EXECUTABLE=ansifilter
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(OBJECTS) -o $@
 
 .cpp.o:
-	$(CC) -c $(CFLAGS) $< -o $@
+	$(CC) -c $(CFLAGS) $(CXXFLAGS) $< -o $@
 
 clean:
 	@rm -f *.o

--- a/src/makefile
+++ b/src/makefile
@@ -6,7 +6,7 @@
 CC=g++
 
 # Added -std=c++11 because of auto_ptr to unique_ptr transition
-CFLAGS= -c -Wall -O2 -DNDEBUG -std=c++11
+CFLAGS= -Wall -O2 -DNDEBUG -std=c++11
 
 LDFLAGS=
 
@@ -23,7 +23,7 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
 
 .cpp.o:
-	$(CC) $(CFLAGS) $< -o $@
+	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
 	@rm -f *.o


### PR DESCRIPTION
`-c` does not belong in CFLAGS. It should always be explicitly set in the compile command. If somebody where to use other CFLAGS, the compile will fail, since nobody specifies `-c` in CFLAGS.

Often people use CXXFLAGS, especially when using a C++ compiler. These flags are passed via CXXFLAGS, which is missing in the Makefile.
EXTRA_LDFLAGS is also a helpful addition.

This change does not affect the current behavior, but prevents possible errors and adds flexibility.

I ran into a few issues, when trying to make it work for MacPorts on OSX < 10.9. I had to patch the makefile and now everything seems to be in order. It would be nice, if you could include these changes upstream, since they don't affect the current behavior, but make the build process a lot easier for packagers and maintainers.