### PR TITLE
add EXTRA_CXXFLAGS to the makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -23,7 +23,7 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(OBJECTS) -o $@
 
 .cpp.o:
-	$(CC) -c $(CXXFLAGS) $< -o $@
+	$(CC) -c $(CXXFLAGS) $(EXTRA_CXXFLAGS) $< -o $@
 
 clean:
 	@rm -f *.o


### PR DESCRIPTION
Your current makefile does not support the use of extra compile flags, since you partly reverted my previous change.

This will allow the use of additional compile flags that might be set by portage systems.