### PR TITLE
fix pango bgcolor property

### DIFF
--- a/src/pangogenerator.cpp
+++ b/src/pangogenerator.cpp
@@ -66,7 +66,7 @@ string PangoGenerator::getOpenTag()
            << "\"";
     }
     if (elementStyle.isBgColorSet()) {
-        fmtStream <<" bgcolor=#\""
+        fmtStream <<" bgcolor=\"#"
            << elementStyle.getBgColour().getRed(HTML)
            << elementStyle.getBgColour().getGreen(HTML)
            << elementStyle.getBgColour().getBlue(HTML)


### PR DESCRIPTION
Thanks for open sourcing your ansifilter, great tool ! I just run some tests and detected a small bug with background color for pango output format (" and # inverted)